### PR TITLE
Criação da rota de API para listagem dos programas

### DIFF
--- a/programa/serializers.py
+++ b/programa/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+from programa.models import Programa
+from drf_extra_fields.fields import Base64ImageField
+
+class SerializadorPrograma(serializers.ModelSerializer):
+  foto_base64 = Base64ImageField(required=False, represent_in_base64=True)
+
+  class Meta:
+      model = Programa
+      exclude = []
+
+  def top_representation(self, instance):
+    representation = super().to_representation(instance)
+    representation['horario'] = instance.horario.strftime('%H:%M:%S')  # Formatando o horário como string
+    return representation

--- a/programa/urls.py
+++ b/programa/urls.py
@@ -1,10 +1,14 @@
 from django.urls import path
-from programa.views import ListarProgramas, FotoPrograma, CriarProgramas, EditarProgramas, DeletarProgramas
+from programa.views import ListarProgramas, FotoPrograma, CriarProgramas, EditarProgramas, DeletarProgramas, APIListarProgramas
 
 urlpatterns = [
   path('', ListarProgramas.as_view(), name='listar-programas'),
   path('novo/', CriarProgramas.as_view(), name='criar-programas'),
   path('<int:pk>/', EditarProgramas.as_view(), name='editar-programas'),
   path('deletar/<int:pk>/', DeletarProgramas.as_view(), name='deletar-programas'),
-  path('fotos/<str:arquivo>', FotoPrograma.as_view(), name='foto-programa')
+  path('fotos/<str:arquivo>', FotoPrograma.as_view(), name='foto-programa'),
+  
+  # API path
+
+  path('api/', APIListarProgramas.as_view(), name='api-listar-programas'),
 ]

--- a/programa/views.py
+++ b/programa/views.py
@@ -6,6 +6,11 @@ from radio_manager.biblioteca import LoginObrigatorio
 from django.http import FileResponse, Http404
 from django.core.exceptions import ObjectDoesNotExist
 
+from rest_framework.generics import ListAPIView
+from programa.serializers import SerializadorPrograma
+# from rest_framework.authentication import TokenAuthentication
+# from rest_framework import permissions
+
 class ListarProgramas(LoginObrigatorio, ListView):
   """
   View para listar os programas cadastrados  
@@ -59,3 +64,14 @@ class FotoPrograma(LoginObrigatorio):
       raise Http404("Foto não encontrada ou acesso não autorizado")
     except Exception as exception:
       raise exception
+    
+class APIListarProgramas(ListAPIView):    
+  """
+  View para listar instâncias do programa (utilizando da API REST)    
+  """
+  serializer_class = SerializadorPrograma    
+  # authentication_classes = [TokenAuthentication]
+  # permission_classes = [permissions.IsAuthenticated]
+
+  def get_queryset(self):        
+    return Programa.objects.all()

--- a/radio_manager/settings.py
+++ b/radio_manager/settings.py
@@ -41,7 +41,11 @@ INSTALLED_APPS = [
 
     "tailwind",
     "theme",
-    "django_browser_reload"
+    "django_browser_reload",
+
+    'corsheaders',
+    'rest_framework',
+    'rest_framework.authtoken'
 ]
 
 TAILWIND_APP_NAME = 'theme'
@@ -62,6 +66,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 
     "django_browser_reload.middleware.BrowserReloadMiddleware",
+    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = "radio_manager.urls"
@@ -141,3 +146,5 @@ STATICFILES_DIRS = [BASE_DIR/'radio_manager'/'static']
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+CORS_ORIGIN_ALLOW_ALL = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,13 @@
 asgiref==3.7.2
 Django==4.2.7
-sqlparse==0.4.4
-tzdata==2023.3
+django-browser-reload==1.12.1
+django-tailwind==3.6.0
+Pillow==10.1.0
 psycopg2-binary==2.9.9
+django-cors-headers==4.3.0
+django-restframework==0.0.1
+djangorestframework==3.14.0
+psycopg2==2.9.9
+pytz==2023.3.post1
+sqlparse==0.4.4
+typing_extensions==4.8.0


### PR DESCRIPTION
Contrução de API para listagem dos programas da Rádio:

- `serializer.py`: classe serializadora de informações complexas para o Json, sendo elas as imagens e o horário;
- `urls.py`: criação da rota que retornará os programas cadastrados e que chamará o método responsável pela listagem;
- `views.py`: método responsável por buscar no banco de dados os programas cadastrados e retornar para a rota endereçada.